### PR TITLE
Fix alert bug and prevent double-click highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,11 @@ body {
     margin: 0;
 }
 
-
+#game-container {
+   -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none;
+}
 
 
     </style>
@@ -144,6 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             alert('No more moves left! Game over!');
         }
+        clearInterval(timerInterval);
         location.reload();
     }
 
@@ -323,7 +328,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 
-    setInterval(() => {
+    const timerInterval = setInterval(() => {
         gameTimer += 1/100;
         // Decrease the time progress bar
         document.getElementById('bar').style.width = `${(TIME - gameTimer) / TIME * 100}%`;


### PR DESCRIPTION
I encountered 1 bug and an improvement opportunity:

## Bug Description

When the game has no more moves to offer, the alert works fine and reloads the page flawlessly. However, if the time runs out, the alerts are infinite which forces the user to click on the browser's reload button. I believe this is not the intended behaviour you had in mind.

## Steps to reproduce

Running on the latest version of Chrome (OS: Ubuntu 22.04 / Android 9), all you have to do is let the green bar timer run out and try to close the alert, you will notice this:

![gif](https://s12.gifyu.com/images/SVA3E.gif)

## Solution

All I had to do was clear the interval after the alert was displayed (either one) to stop the interval from stacking alerts every 10 milliseconds (Firefox does not do this).

---

The improvement is just a CSS style to prevent the icons from turning blue (selection highlight) after double clicks which is annoying. Again, this also doesn't happen in Firefox but it does in Chrome.

Another thing I did notice in Firefox is that the timer bar seemed laggy, which I am guessing can be fixed by replacing the interval with a `requestAnimationFrame` (this supposedly runs every 16ms).